### PR TITLE
Fix crash on android

### DIFF
--- a/src/MashView.tsx
+++ b/src/MashView.tsx
@@ -112,7 +112,8 @@ function MashView(props: MashViewProps) {
 
   const animatedPropsBackdrop = useAnimatedProps(() => {
     return {
-      fill: interpolateColor(progress.value, [0, 1], ['rgba(0, 0, 0, 0)', `rgba(0, 0, 0, ${options?.backdropOpacity ?? 0.8})`]),
+      //fill: interpolateColor(progress.value, [0, 1], ['rgba(0, 0, 0, 0)', `rgba(0, 0, 0, ${options?.backdropOpacity ?? 0.8})`]),
+      fillOpacity: interpolate(progress.value, [0, 1], [0, 1]),
     };
   });
 
@@ -254,6 +255,7 @@ function MashView(props: MashViewProps) {
           animatedProps={animatedPropsBackdrop}
           height="100%"
           width="100%"
+          fill={`rgba(0,0,0,${options?.backdropOpacity || 0.8})`}
           mask="url(#mask)"
           fill-opacity="0"
         />


### PR DESCRIPTION
this code, crash android, check this https://github.com/software-mansion/react-native-reanimated/issues/3775
```
return fill: interpolateColor(progress.value, [0, 1], ['rgba(0, 0, 0, 0)', `rgba(0, 0, 0, ${options?.backdropOpacity ?? 0.8})`]),
```

so instead of animating the color, I change it to animate the opacity,
```
return fillOpacity: interpolate(progress.value, [0, 1], [0, 1]),
```